### PR TITLE
use craftctl instead of snapcraftctl on core22+

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,9 +26,10 @@ parts:
     plugin: python
     source-type: git
     source: https://github.com/liquidctl/liquidctl
+    source-depth: 1
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version \
+      craftctl default
+      craftctl set version=\
       "$(git describe --long --tags --always --match=v*.*.* | sed 's/v//')"
     stage-packages:
        - python3-usb


### PR DESCRIPTION
According to the doc: https://snapcraft.io/docs/using-craftctl
should use `craftctl` with a core22 or higher.